### PR TITLE
Make identity param consistent for PI and AF Mappings

### DIFF
--- a/DSCResources/xAFMapping/xAFMapping.psm1
+++ b/DSCResources/xAFMapping/xAFMapping.psm1
@@ -43,7 +43,7 @@ function Get-TargetResource
         Name = $mapping.Name;
         Description = $mapping.Description;
         Account = $mapping.AccountDisplayName;
-        AFIdentityName = $mapping.SecurityIdentity.Name;
+        Identity = $mapping.SecurityIdentity.Name;
         Ensure = $Ensure;
     }
 
@@ -59,7 +59,7 @@ function Set-TargetResource
         $Description,
 
         [System.String]
-        $AFIdentityName,
+        $Identity,
 
         [parameter(Mandatory = $true)]
         [System.String]
@@ -105,18 +105,18 @@ function Set-TargetResource
             {
                 Write-Verbose "Removing and resetting AF Mapping '$Name'"
                 Remove-AFMappingDSC -AFServer $AFServer -Name $Name
-                Add-AFMappingDSC -AFServer $AFServer -Name $Name -Description $Description -Account $Account -Identity $AFIdentityName
+                Add-AFMappingDSC -AFServer $AFServer -Name $Name -Description $Description -Account $Account -Identity $Identity
             }
             else
             {
                 Write-Verbose "Setting AF Mapping '$Name'"
-                Set-AFMappingDSC -AFServer $AFServer -Name $Name -Identity $AFIdentityName -Description $Description
+                Set-AFMappingDSC -AFServer $AFServer -Name $Name -Identity $Identity -Description $Description
             }
         }
         else
         {
             Write-Verbose "Adding AF Mapping '$Name'"
-            Add-AFMappingDSC -AFServer $AFServer -Name $Name -Description $Description -Account $Account -Identity $AFIdentityName
+            Add-AFMappingDSC -AFServer $AFServer -Name $Name -Description $Description -Account $Account -Identity $Identity
         }
     }
     else
@@ -136,7 +136,7 @@ function Test-TargetResource
         $Description,
 
         [System.String]
-        $AFIdentityName,
+        $Identity,
 
         [parameter(Mandatory = $true)]
         [System.String]
@@ -248,7 +248,7 @@ function Add-AFMappingDSC
 
     $AF = Connect-AFServerUsingSDK -AFServer $AFServer
 
-    # Check if the specified Account and AFIdentityName are valid, stop if not.
+    # Check if the specified Account and Identity are valid, stop if not.
     $ErrorActionPreference = 'Stop'
     $ntAccount = Get-NTAccount -AccountName $Account # will throw exception if invalid
     $AFIdentity = Get-ValidAFIdentity -AFServer $AFServer -Identity $Identity

--- a/DSCResources/xAFMapping/xAFMapping.schema.mof
+++ b/DSCResources/xAFMapping/xAFMapping.schema.mof
@@ -20,7 +20,7 @@
 class xAFMapping : OMI_BaseResource
 {
     [Write, Description("Description")] String Description;
-    [Write, Description("AF Identity Name")] String AFIdentityName;
+    [Write, Description("AF Identity Name")] String Identity;
     [Required, Description("AF Server name for connection")] String AFServer;
     [Key, Description("unique name")] String Name;
     [Write, ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;

--- a/Examples/xAFMapping_AddAFMapping.ps1
+++ b/Examples/xAFMapping_AddAFMapping.ps1
@@ -9,7 +9,7 @@ Configuration AddAFMappingExample
 			Name = "PIReader"
             Description = "Read-only user role."
             Account = "Domain\Domain Users"
-            AFIdentityName = "PIReaders"
+            Identity = "PIReaders"
             Ensure = "Present"
             AFServer = "localhost"
 		}

--- a/Tests/Integration/xAFMapping.config.ps1
+++ b/Tests/Integration/xAFMapping.config.ps1
@@ -3,7 +3,7 @@ $ConfigurationData = @{
         @{
             NodeName = 'localhost'
             Name = "IntegrationTempMapping"
-            AFIdentityName = "IntegrationTempIdentity"
+            Identity = "IntegrationTempIdentity"
         }
     )
 }
@@ -15,14 +15,14 @@ Configuration xAFMapping_Set
         [System.String] $Description
     )
 
-    Import-DscResource -ModuleName PISecurityDSC 
- 
+    Import-DscResource -ModuleName PISecurityDSC
+
     Node localhost
     {
-        AFIdentity $($Node.AFIdentityName)
+        AFIdentity $($Node.Identity)
         {
             AFServer = $Node.NodeName
-            Name = $($Node.AFIdentityName)
+            Name = $($Node.Identity)
             Ensure = "Present"
             IsEnabled = $true
         }
@@ -32,19 +32,19 @@ Configuration xAFMapping_Set
             AFServer = $Node.NodeName
             Name = $Node.Name
             Account = "NT Authority\" + $Account
-            AFIdentityName = $Node.AFIdentityName
+            Identity = $Node.Identity
             Description = $Description
             Ensure = "Present"
-            DependsOn = "[AFIdentity]$($Node.AFIdentityName)"
-        } 
+            DependsOn = "[AFIdentity]$($Node.Identity)"
+        }
     }
 }
 
 Configuration xAFMapping_Remove
 {
     param()
-    Import-DscResource -ModuleName PISecurityDSC 
- 
+    Import-DscResource -ModuleName PISecurityDSC
+
     Node localhost
     {
         AFMapping xAFMapping_RemoveIntegration
@@ -52,21 +52,21 @@ Configuration xAFMapping_Remove
             AFServer = $Node.NodeName
             Name = $Node.Name
             Ensure = "Absent"
-        } 
+        }
     }
 }
 
 Configuration xAFMapping_CleanUp
 {
     param()
-    Import-DscResource -ModuleName PISecurityDSC 
- 
+    Import-DscResource -ModuleName PISecurityDSC
+
     Node localhost
     {
-        AFIdentity $($Node.AFIdentityName)
+        AFIdentity $($Node.Identity)
         {
             AFServer = $Node.NodeName
-            Name = $($Node.AFIdentityName)
+            Name = $($Node.Identity)
             Ensure = "Absent"
         }
     }

--- a/Tests/Unit/xAFMapping.Unit.Tests.ps1
+++ b/Tests/Unit/xAFMapping.Unit.Tests.ps1
@@ -36,7 +36,7 @@ try
         $testAFServer = 'localhost'
         $defaultParameters = @{
                                 Description = "This is a mapping"
-                                AFIdentityName = "UnitTestIdentity"
+                                Identity = "UnitTestIdentity"
                                 AFServer = $testAFServer
                                 Name = "UnitTestMapping"
                                 Ensure = "Present"
@@ -48,7 +48,7 @@ try
                 InputParameters = $defaultParameters
                 MockValue = @{
                         Description = "This is a mapping"
-                        AFIdentityName = "UnitTestIdentity"
+                        Identity = "UnitTestIdentity"
                         AFServer = $testAFServer
                         Name = "UnitTestMapping"
                         Ensure = "Present"
@@ -80,7 +80,7 @@ try
                 InputParameters = $defaultParameters
                 MockValue = @{
                         Description = "Wrong description!!!"
-                        AFIdentityName = "UnitTestIdentity"
+                        Identity = "UnitTestIdentity"
                         AFServer = $testAFServer
                         Name = "UnitTestMapping"
                         Ensure = "Present"
@@ -115,7 +115,7 @@ try
             {
                 $MockAFMapping = New-Object PSCustomObject
                 $SecurityIdentity = New-Object PSCustomObject
-                $SecurityIdentity | Add-Member -MemberType NoteProperty -Name Name -Value $InputEntry.AFIdentityName -TypeName string
+                $SecurityIdentity | Add-Member -MemberType NoteProperty -Name Name -Value $InputEntry.Identity -TypeName string
                 $MockAFMapping | Add-Member -MemberType NoteProperty -Name SecurityIdentity -Value $SecurityIdentity
                 $MockAFMapping | Add-Member -MemberType NoteProperty -Name Description -Value $InputEntry.Description -TypeName string
                 $MockAFMapping | Add-Member -MemberType NoteProperty -Name Ensure -Value $InputEntry.Ensure -TypeName string


### PR DESCRIPTION
Refactor AFMapping to use Identity instead of AFIdentityName to be consistent with PIMapping resource schema.  Clear bill of health on all unit, integration, and xDscResourceDesigner tests.